### PR TITLE
Update AmazonIVSPlayer to version 1.3.3

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -1,7 +1,7 @@
 platform :ios, '10.0'
 
 target 'eCommerce' do
-    pod 'AmazonIVSPlayer', '~> 1.2.0'
+    pod 'AmazonIVSPlayer', '~> 1.3.3'
 end
 
 # Allow building for arm64e architecture, which AmazonIVSPlayer supports.

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,16 +1,16 @@
 PODS:
-  - AmazonIVSPlayer (1.2.0)
+  - AmazonIVSPlayer (1.3.3)
 
 DEPENDENCIES:
-  - AmazonIVSPlayer (~> 1.2.0)
+  - AmazonIVSPlayer (~> 1.3.3)
 
 SPEC REPOS:
   trunk:
     - AmazonIVSPlayer
 
 SPEC CHECKSUMS:
-  AmazonIVSPlayer: d0f971e303558c04bbe70692292db7378650f8ad
+  AmazonIVSPlayer: 43482c52521fbe36c6fdee48eb336fbcda87be7a
 
-PODFILE CHECKSUM: 3426990aacd792c3a276ae23950685e05f9258cb
+PODFILE CHECKSUM: 9a6125141d6d20e9f8810d1b7e4104fefa5ef46a
 
 COCOAPODS: 1.10.1


### PR DESCRIPTION
- Use latest AmazonIVSPlayer version 1.3.3

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
